### PR TITLE
Fix bucket calculation

### DIFF
--- a/src/services/calculateBuckets.ts
+++ b/src/services/calculateBuckets.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js'
 
-export default (uuid: string, defaultValue = 0): number => {
+export default (uuid: string, defaultValue = 100): number => {
     // This calculation is broken.
     // Normally we would calculate with new BN(x).mod(new BN(100)).toNumber() + 1;
     // BUT: the existing scala client is doing strange calculation.
@@ -13,18 +13,13 @@ export default (uuid: string, defaultValue = 0): number => {
         return defaultValue
     }
 
-    const x = uuid.replace(/-/g, '')
+    const hi = new BN(strippedUUID.substr(0, 16), 16)
+    const lo = new BN(strippedUUID.substr(16, 16), 16)
 
-    const hi = new BN(x.substr(0, 16), 16)
-    const lo = new BN(x.substr(16, 16), 16)
-
-    const r =
-        lo
-            .shln(64)
-            .add(hi)
+    return lo
+            .ishln(64)
+            .iadd(hi)
             .fromTwos(128)
-            .mod(new BN(100))
+            .umod(new BN(100))
             .toNumber() + 1
-
-    return r < 0 ? 100 + r : r
 }

--- a/src/services/calculateBuckets.ts
+++ b/src/services/calculateBuckets.ts
@@ -1,11 +1,7 @@
 import BN from 'bn.js'
 
 export default (uuid: string, defaultValue = 100): number => {
-    // This calculation is broken.
-    // Normally we would calculate with new BN(x).mod(new BN(100)).toNumber() + 1;
-    // BUT: the existing scala client is doing strange calculation.
-    // See thread here: https://github.com/AutoScout24/toguru-scala-client/pull/27
-
+    // Bucket calculation aligned with https://github.com/AutoScout24/toguru-scala-client/pull/27
     const strippedUUID = uuid.replace(/-/g, '')
     const isUUIDInvalid = strippedUUID.length !== 32
 
@@ -16,10 +12,12 @@ export default (uuid: string, defaultValue = 100): number => {
     const hi = new BN(strippedUUID.substr(0, 16), 16)
     const lo = new BN(strippedUUID.substr(16, 16), 16)
 
-    return lo
+    return (
+        lo
             .ishln(64)
             .iadd(hi)
             .fromTwos(128)
             .umod(new BN(100))
             .toNumber() + 1
+    )
 }

--- a/src/services/isToggleEnabled.ts
+++ b/src/services/isToggleEnabled.ts
@@ -18,7 +18,7 @@ export default (
     // return default if the toggle is not set
     if (!toggleData) return toggle.default
     // if the uuid is not defined and the rollout is 100%, then the toggle activation depends only on the attributes
-    const bucket = uuid ? calculateBucket(uuid, toggle.default ? 100 : 0) : 100
+    const bucket = uuid ? calculateBucket(uuid, 100) : 100
     const rolloutAttributes: Record<string, string[]> = toggleData?.activations[0]?.attributes || {}
 
     // Attributes are present in the toggle toguru data, but not present in the activation context

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -43,8 +43,8 @@ describe('Toguru Client', () => {
             expect(
                 client({
                     ...userInBucket22CultureDE,
-                    forcedToggles: { 'rolled-out-to-noone': true },
-                }).isToggleEnabled({ id: 'rolled-out-to-noone', default: false }),
+                    forcedToggles: { 'rolled-out-to-none': true },
+                }).isToggleEnabled({ id: 'rolled-out-to-none', default: false }),
             ).toBe(true)
         })
 
@@ -97,7 +97,7 @@ describe('Toguru Client', () => {
             expect(client(userInBucket22CultureDE).togglesForService('service2')).toEqual(
                 new Toggles([
                     { id: 'rolled-out-to-half-in-de-only', enabled: true },
-                    { id: 'rolled-out-to-noone', enabled: false },
+                    { id: 'rolled-out-to-none', enabled: false },
                 ]),
             )
         })

--- a/test/express/bridge.spec.ts
+++ b/test/express/bridge.spec.ts
@@ -57,7 +57,7 @@ const sendRequest = async ({
 const toggles: Record<string, Toggle> = {
     rolledOutToEveryone: { id: 'rolled-out-to-everyone', default: false },
     rolledOutToHalfInDeOnly: { id: 'rolled-out-to-half-in-de-only', default: false },
-    rolledOutToNone: { id: 'rolled-out-to-noone', default: false },
+    rolledOutToNone: { id: 'rolled-out-to-none', default: false },
 }
 
 const userInBucket22CultureDE = {
@@ -104,7 +104,7 @@ describe('Express middleware', () => {
                     enabled: true,
                 },
                 {
-                    id: 'rolled-out-to-noone',
+                    id: 'rolled-out-to-none',
                     enabled: false,
                 },
             ]),
@@ -121,7 +121,7 @@ describe('Express middleware', () => {
                     enabled: false,
                 },
                 {
-                    id: 'rolled-out-to-noone',
+                    id: 'rolled-out-to-none',
                     enabled: false,
                 },
             ]),
@@ -133,7 +133,7 @@ describe('Express middleware', () => {
 
         expect(req.toguru).toBeDefined()
         expect(req.toguru?.togglesForService('service2').queryString).toEqual(
-            'toguru=rolled-out-to-half-in-de-only%3Dfalse%7Crolled-out-to-noone%3Dfalse',
+            'toguru=rolled-out-to-half-in-de-only%3Dfalse%7Crolled-out-to-none%3Dfalse',
         )
     })
 
@@ -141,7 +141,7 @@ describe('Express middleware', () => {
         const req = await sendRequest({
             ...userInBucketb76CultureDE,
             query: {
-                toguru: 'rolled-out-to-noone=true|rolled-out-to-half-in-de-only=true',
+                toguru: 'rolled-out-to-none=true|rolled-out-to-half-in-de-only=true',
             },
         })
 

--- a/test/mocks/togglestate.fixture.json
+++ b/test/mocks/togglestate.fixture.json
@@ -125,6 +125,21 @@
                     }
                 }
             ]
+        },
+        {
+            "id": "rolled-out-to-user123-in-de",
+            "tags": {},
+            "activations": [
+                {
+                    "attributes": {
+                        "culture": ["de-DE"],
+                        "user": ["user123"]
+                    },
+                    "rollout": {
+                        "percentage": 100
+                    }
+                }
+            ]
         }
     ]
 }

--- a/test/mocks/togglestate.fixture.json
+++ b/test/mocks/togglestate.fixture.json
@@ -53,6 +53,20 @@
             ]
         },
         {
+            "id": "rolled-out-only-in-it",
+            "tags": { },
+            "activations": [
+                {
+                    "attributes": {
+                        "culture": ["it-IT", "IT"]
+                    },
+                    "rollout": {
+                        "percentage": 100
+                    }
+                }
+            ]
+        },
+        {
             "id": "rolled-out-to-none-not-even-in-de",
             "tags": {
                 "team": "team5",
@@ -96,6 +110,18 @@
                     "attributes": {},
                     "rollout": {
                         "percentage": 0
+                    }
+                }
+            ]
+        },    
+        {
+            "id": "rolled-out-to-99-percent",
+            "tags": {},
+            "activations": [
+                {
+                    "attributes": {},
+                    "rollout": {
+                        "percentage": 99
                     }
                 }
             ]

--- a/test/mocks/togglestate.fixture.json
+++ b/test/mocks/togglestate.fixture.json
@@ -54,7 +54,7 @@
         },
         {
             "id": "rolled-out-only-in-it",
-            "tags": { },
+            "tags": {},
             "activations": [
                 {
                     "attributes": {
@@ -100,7 +100,7 @@
             ]
         },
         {
-            "id": "rolled-out-to-noone",
+            "id": "rolled-out-to-none",
             "tags": {
                 "team": "team7",
                 "service": "service2"
@@ -113,7 +113,7 @@
                     }
                 }
             ]
-        },    
+        },
         {
             "id": "rolled-out-to-99-percent",
             "tags": {},
@@ -137,6 +137,30 @@
                     },
                     "rollout": {
                         "percentage": 100
+                    }
+                }
+            ]
+        },
+        {
+            "id": "rolled-out-to-76-percent",
+            "tags": {},
+            "activations": [
+                {
+                    "attributes": {},
+                    "rollout": {
+                        "percentage": 76
+                    }
+                }
+            ]
+        },
+        {
+            "id": "rolled-out-to-75-percent",
+            "tags": {},
+            "activations": [
+                {
+                    "attributes": {},
+                    "rollout": {
+                        "percentage": 75
                     }
                 }
             ]

--- a/test/services/calculateBucket.spec.ts
+++ b/test/services/calculateBucket.spec.ts
@@ -3,10 +3,7 @@ import calc from '../../src/services/calculateBuckets'
 describe('Calculate bucket from uuid', () => {
     it('Bucket is calculated correctly for ea', () => {
         // Test cases below taken from toguru scala client
-        // But they seem to be wrong
-        // Still under clarification whwat the scala code is doing
-        // https://github.com/andreas-schroeder/toguru-scala-client/blob/master/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala#L40
-
+        // https://github.com/Autoscout24/toguru-scala-client
         expect(calc('92cccc65-3ee8-4fa8-a663-632dd282f42f')).toEqual(1)
         expect(calc('ef4ff1f7-d0d6-4129-b823-818e39b8dc24')).toEqual(6)
         expect(calc('5f908fdb-e569-4a2e-973f-73fe51b8a337')).toEqual(11)
@@ -27,5 +24,8 @@ describe('Calculate bucket from uuid', () => {
         expect(calc('86bf949b-a75b-44b2-8e66-2f766fa43f48')).toEqual(91)
         expect(calc('476893d9-65cd-410d-a294-ac086c5fffa3')).toEqual(94)
         expect(calc('88d8bbd2-809f-4edf-a38e-7a98dddc06a3')).toEqual(96)
+        expect(calc('777baa8c-e289-4b46-8de7-3d904e041950')).toEqual(99)
+        expect(calc('b2d886c9-a7d8-469f-83e7-483a1ce97ac7')).toEqual(100)
+        expect(calc('c14280be-1659-464b-bbf7-4968a7513c76')).toEqual(100)
     })
 })

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -41,7 +41,7 @@ const testToggleForUsers = (
     cases: { user: ActivationContext; expectedIsEnabled: boolean }[],
     forcedToggles: Record<string, boolean> = {},
 ) => {
-    test.each(cases)(`${toggle.id} for %o`,(c) => {
+    test.each(cases)(`${toggle.id} for %o`, (c) => {
         expect(isEnabled(toggleState, toggle, { ...c.user, forcedToggles })).toBe(c.expectedIsEnabled)
     })
 }

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -41,10 +41,8 @@ const testToggleForUsers = (
     cases: { user: ActivationContext; expectedIsEnabled: boolean }[],
     forcedToggles: Record<string, boolean> = {},
 ) => {
-    it(toggle.id, () => {
-        cases.forEach((c) => {
-            expect(isEnabled(toggleState, toggle, { ...c.user, forcedToggles })).toBe(c.expectedIsEnabled)
-        })
+    test.each(cases)(`${toggle.id} for %o`,(c) => {
+        expect(isEnabled(toggleState, toggle, { ...c.user, forcedToggles })).toBe(c.expectedIsEnabled)
     })
 }
 

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -1,168 +1,136 @@
 import isEnabled from '../../src/services/isToggleEnabled'
 import { ToguruData, ActivationContext } from '../../src/models/toguru'
 import toggleState from '../mocks/togglestate.fixture.json'
+import { Toggle } from '../../src/models/Toggle'
 
-const userInBucket22CultureDE = {
-    attributes: { culture: 'de-DE' },
-    uuid: '88248687-6dce-4759-a5c0-3945eedc2b48',
-} // bucket: 22
-const userInBucket76CultureDE = {
-    attributes: { culture: 'de-DE' },
-    uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
-} // bucket: 76
-const userInBucket22CultureIT = {
-    attributes: { culture: 'it-IT' },
-    uuid: '88248687-6dce-4759-a5c0-3945eedc2b48',
-} // bucket: 22
-const userInBucket76CultureIT: ActivationContext = {
-    attributes: { culture: 'it-IT' },
-    uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
-} // bucket: 76
-const userWithoutUUID = { attributes: { culture: 'de-DE' } }
-const userEmpty = {}
-const user123 = { attributes: { culture: 'de-DE' , user: 'user123'} }
+const users = {
+    bucket76: {
+        attributes: {},
+        uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
+    },
+    bucket22CultureDE: {
+        attributes: { culture: 'de-DE' },
+        uuid: '88248687-6dce-4759-a5c0-3945eedc2b48',
+    },
+    bucket76CultureDE: {
+        attributes: { culture: 'de-DE' },
+        uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
+    },
+    bucket22CultureIT: {
+        attributes: { culture: 'it-IT' },
+        uuid: '88248687-6dce-4759-a5c0-3945eedc2b48',
+    },
+    bucket76CultureIT: {
+        attributes: { culture: 'it-IT' },
+        uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
+    },
+    withoutUUIDWithAttributes: { attributes: { culture: 'de-DE' } },
+    empty: {},
+    attributeUserId123: { attributes: { user: 'user123' } },
+}
 
 const emptyToguruData: ToguruData = { sequenceNo: 0, toggles: [] }
 
-const toggle = (id: string, defaultValue = false) => ({ id, default: defaultValue })
+const toggle = (id: string, defaultValue = false) => ({
+    id,
+    default: defaultValue,
+})
 
-describe('Is Toggle Enabled', () => {
-    it('empty toggles state', () => {
-        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', true), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', false), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', true), userEmpty)).toBe(true)
-        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', false), userEmpty)).toBe(false)
+const testToggleForUsers = (
+    toggle: Toggle,
+    cases: { user: ActivationContext; expectedIsEnabled: boolean }[],
+    forcedToggles: Record<string, boolean> = {},
+) => {
+    it(toggle.id, () => {
+        cases.forEach((c) => {
+            expect(isEnabled(toggleState, toggle, { ...c.user, forcedToggles })).toBe(c.expectedIsEnabled)
+        })
+    })
+}
+
+describe('isToggleEnabled', () => {
+    it('when there is no toggles state should match the default condition', () => {
+        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', true), users.bucket22CultureDE)).toBe(true)
+        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', false), users.bucket22CultureDE)).toBe(false)
+        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', true), users.empty)).toBe(true)
+        expect(isEnabled(emptyToguruData, toggle('doesnt-matter', false), users.empty)).toBe(false)
     })
 
-    it('rolled-out-to-noone', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), userEmpty)).toBe(false)
+    it('should return true if the rollout percentage is bigger or equal to the bucket the user is in', () => {
+        expect(isEnabled(toggleState, toggle('rolled-out-to-76-percent', false), users.bucket76)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-75-percent', true), users.bucket76)).toBe(false)
     })
 
-    it('with-empty-activation', () => {
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('with-empty-activation'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(
+        toggle('rolled-out-to-none'),
+        Object.values(users).map((u) => ({ user: u, expectedIsEnabled: false })),
+    )
 
-    it('unknown toggle', () => {
-        expect(isEnabled(toggleState, toggle('unknown-toggle'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('unknown-toggle'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(
+        toggle('with-empty-activation'),
+        Object.values(users).map((u) => ({ user: u, expectedIsEnabled: false })),
+    )
 
-    it('rolled-out-to-everyone', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userInBucket76CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userInBucket22CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userInBucket76CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userWithoutUUID)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-everyone'), userEmpty)).toBe(true)
-    })
+    testToggleForUsers(
+        toggle('unknown-toggle'),
+        Object.values(users).map((u) => ({ user: u, expectedIsEnabled: false })),
+    )
 
-    it('rolled-out-to-half-of-users', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userInBucket22CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-of-users'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(
+        toggle('rolled-out-to-everyone'),
+        Object.values(users).map((u) => ({ user: u, expectedIsEnabled: true })),
+    )
 
-    it('rolled-out-only-in-de', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userInBucket76CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userWithoutUUID)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(toggle('rolled-out-to-half-of-users'), [
+        { user: users.bucket22CultureDE, expectedIsEnabled: true },
+        { user: users.bucket76CultureDE, expectedIsEnabled: false },
+        { user: users.bucket22CultureIT, expectedIsEnabled: true },
+        { user: users.bucket76CultureIT, expectedIsEnabled: false },
+        { user: users.withoutUUIDWithAttributes, expectedIsEnabled: false },
+        { user: users.empty, expectedIsEnabled: false },
+    ])
 
-    it('rolled-out-only-in-it', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket22CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket76CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(
+        toggle('rolled-out-only-in-de'),
+        Object.values<ActivationContext>(users).map((u) => ({
+            user: u,
+            expectedIsEnabled:
+                (u.attributes && u.attributes.culture && u.attributes.culture.includes('de-DE')) || false,
+        })),
+    )
 
-    it('rolled-out-to-none-not-even-in-de', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(
+        toggle('rolled-out-only-in-it'),
+        Object.values<ActivationContext>(users).map((u) => ({
+            user: u,
+            expectedIsEnabled:
+                (u.attributes && u.attributes.culture && u.attributes.culture.includes('it-IT')) || false,
+        })),
+    )
 
-    it('rolled-out-to-half-in-de-only', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userEmpty)).toBe(false)
-    })
+    testToggleForUsers(toggle('rolled-out-to-half-in-de-only'), [
+        { user: users.bucket22CultureDE, expectedIsEnabled: true },
+        { user: users.bucket76CultureDE, expectedIsEnabled: false },
+        { user: users.bucket22CultureIT, expectedIsEnabled: false },
+        { user: users.bucket76CultureIT, expectedIsEnabled: false },
+        { user: users.withoutUUIDWithAttributes, expectedIsEnabled: false },
+        { user: users.empty, expectedIsEnabled: false },
+    ])
 
-    it('rolled-out-to-99-percent', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket22CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket76CultureDE)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket22CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket76CultureIT)).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userEmpty)).toBe(false)
-    })
-    
-    it('rolled-out-to-user123-in-de', () => {
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket22CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket76CultureDE)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket22CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket76CultureIT)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userWithoutUUID)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userEmpty)).toBe(false)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), user123)).toBe(true)
-    })
+    testToggleForUsers(toggle('rolled-out-to-user123-in-de'), [
+        ...Object.values(users).map((u) => ({ user: u, expectedIsEnabled: false })),
+        {
+            user: {
+                ...users.attributeUserId123,
+                attributes: { ...users.attributeUserId123.attributes, culture: 'de-DE' },
+            },
+            expectedIsEnabled: true,
+        },
+    ])
 
-    it('forced toggles', () => {
-        const forcedToggles = { 'rolled-out-to-noone': true }
-
-        expect(
-            isEnabled(toggleState, toggle('rolled-out-to-noone'), {
-                ...userInBucket22CultureDE,
-                forcedToggles,
-            }),
-        ).toBe(true)
-        expect(
-            isEnabled(toggleState, toggle('rolled-out-to-noone'), {
-                ...userInBucket76CultureDE,
-                forcedToggles,
-            }),
-        ).toBe(true)
-        expect(
-            isEnabled(toggleState, toggle('rolled-out-to-noone'), {
-                ...userInBucket22CultureIT,
-                forcedToggles,
-            }),
-        ).toBe(true)
-        expect(
-            isEnabled(toggleState, toggle('rolled-out-to-noone'), {
-                ...userInBucket76CultureIT,
-                forcedToggles,
-            }),
-        ).toBe(true)
-        expect(
-            isEnabled(toggleState, toggle('rolled-out-to-noone'), {
-                ...userWithoutUUID,
-                forcedToggles,
-            }),
-        ).toBe(true)
-        expect(isEnabled(toggleState, toggle('rolled-out-to-noone'), { forcedToggles })).toBe(true)
-    })
+    testToggleForUsers(
+        toggle('rolled-out-to-none'),
+        Object.values(users).map((u) => ({ user: u, expectedIsEnabled: true })),
+        { 'rolled-out-to-none': true },
+    )
 })

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -18,7 +18,7 @@ const userInBucket76CultureIT: ActivationContext = {
     attributes: { culture: 'it-IT' },
     uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
 } // bucket: 76
-const userWithoutUUID = { attributes: { culture: 'de-DE' } } // bucket: 1
+const userWithoutUUID = { attributes: { culture: 'de-DE' } } // bucket: 100
 const userEmpty = {}
 
 const emptyToguruData: ToguruData = { sequenceNo: 0, toggles: [] }
@@ -83,6 +83,15 @@ describe('Is Toggle Enabled', () => {
         expect(isEnabled(toggleState, toggle('rolled-out-only-in-de'), userEmpty)).toBe(false)
     })
 
+    it('rolled-out-only-in-it', () => {
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket22CultureDE)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket76CultureDE)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket22CultureIT)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userInBucket76CultureIT)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userWithoutUUID)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-only-in-it'), userEmpty)).toBe(false)
+    })
+
     it('rolled-out-to-none-not-even-in-de', () => {
         expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket22CultureDE)).toBe(false)
         expect(isEnabled(toggleState, toggle('rolled-out-to-none-not-even-in-de'), userInBucket76CultureDE)).toBe(false)
@@ -99,6 +108,15 @@ describe('Is Toggle Enabled', () => {
         expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userInBucket76CultureIT)).toBe(false)
         expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userWithoutUUID)).toBe(false)
         expect(isEnabled(toggleState, toggle('rolled-out-to-half-in-de-only'), userEmpty)).toBe(false)
+    })
+
+    it('rolled-out-to-99-percent', () => {
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket22CultureDE)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket76CultureDE)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket22CultureIT)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket76CultureIT)).toBe(true)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userWithoutUUID)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userEmpty)).toBe(false)
     })
 
     it('forced toggles', () => {

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -18,8 +18,9 @@ const userInBucket76CultureIT: ActivationContext = {
     attributes: { culture: 'it-IT' },
     uuid: '721f87e2-cec9-4753-b3bb-d2ebe20dd317',
 } // bucket: 76
-const userWithoutUUID = { attributes: { culture: 'de-DE' } } // bucket: 100
+const userWithoutUUID = { attributes: { culture: 'de-DE' } }
 const userEmpty = {}
+const user123 = { attributes: { culture: 'de-DE' , user: 'user123'} }
 
 const emptyToguruData: ToguruData = { sequenceNo: 0, toggles: [] }
 
@@ -117,6 +118,16 @@ describe('Is Toggle Enabled', () => {
         expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userInBucket76CultureIT)).toBe(true)
         expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userWithoutUUID)).toBe(false)
         expect(isEnabled(toggleState, toggle('rolled-out-to-99-percent'), userEmpty)).toBe(false)
+    })
+    
+    it('rolled-out-to-user123-in-de', () => {
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket22CultureDE)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket76CultureDE)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket22CultureIT)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userInBucket76CultureIT)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userWithoutUUID)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), userEmpty)).toBe(false)
+        expect(isEnabled(toggleState, toggle('rolled-out-to-user123-in-de'), user123)).toBe(true)
     })
 
     it('forced toggles', () => {


### PR DESCRIPTION
The scope of the PR is fix a bug in the calculation for the user's bucket.
A small percentage of our users where assigned to a `bucket 0` meaning that every toggle was turned on for them.

On the bucket calculation code this is what `i` and `u` mean 
> i - perform operation in-place, storing the result in the host object (on which the method was invoked). Might be used to avoid number allocation costs
u - unsigned, ignore the sign of operands when performing operation, or always return positive value. Second case applies to reduction operations like mod(). In such cases if the result will be negative - modulo will be added to the result to make it positive

from: https://github.com/indutny/bn.js#prefixes 

Other changes:
- The default bucket for the calculation if the uuid is not valid is 100 
- The default bucket doesn't change based on the toggle's default if toggles data are present
- Added a test for a couple of failing ids (randomly generated)
- Improve the tests for the `isToggleEnabled` service