### PR TITLE
Precalculating toggles for each service to speed up lookup time

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -35,7 +35,7 @@ export type TogglingApiByActivationContext = (context: ActivationContext) => Tog
 
 export default (config: ToguruClientConfig): TogglingApiByActivationContext => {
     const { endpoint, refreshIntervalMs = refreshIntervalMsDefault } = config
-    let toguruData: ToguruData = { sequenceNo: 0, toggles: [] }
+    let toguruData: ToguruData = { sequenceNo: 0, toggles: [], toggleIdsByService: new Map() }
 
     const refreshToguruData = () =>
         fetchToguruData(endpoint)

--- a/src/models/toguru.ts
+++ b/src/models/toguru.ts
@@ -26,7 +26,11 @@ export type ToguruToggleData = {
     }>
 }
 
-export type ToguruData = {
+export type RawToguruData = {
     sequenceNo: number
     toggles: ToguruToggleData[]
+}
+
+export type ToguruData = RawToguruData & {
+    toggleIdsByService: Map<string, string[]>
 }

--- a/src/services/fetchToguruData.ts
+++ b/src/services/fetchToguruData.ts
@@ -1,9 +1,29 @@
 import axios from 'axios'
-import { ToguruData } from '../models/toguru'
+import { RawToguruData, ToguruData } from '../models/toguru'
+
+export const convertRawToguruDataToToguruData: (toguruData: RawToguruData) => ToguruData = (toguruData) => {
+    const toggleIdsByService: ToguruData['toggleIdsByService'] = new Map()
+
+    toguruData.toggles.forEach((toggle) => {
+        ;(toggle.tags['services'] || '')
+            .split(',')
+            .concat(toggle.tags['service'])
+            .forEach((service) => {
+                service && toggleIdsByService.has(service)
+                    ? toggleIdsByService.get(service)?.push(toggle.id)
+                    : toggleIdsByService.set(service, [toggle.id])
+            })
+    })
+
+    return {
+        ...toguruData,
+        toggleIdsByService,
+    }
+}
 
 export default (endpoint: string): Promise<ToguruData> =>
     axios(endpoint, {
         headers: {
             Accept: 'application/vnd.toguru.v3+json',
         },
-    }).then(({ data }) => data as ToguruData)
+    }).then(({ data }: { data: RawToguruData }) => convertRawToguruDataToToguruData(data))

--- a/src/services/toggleListForService.ts
+++ b/src/services/toggleListForService.ts
@@ -1,13 +1,5 @@
-import { ToguruToggleData, ToguruData } from '../models/toguru'
-
-const toggleBelongsToService = (toggle: ToguruToggleData, serviceName: string): boolean => {
-    const service = (toggle?.tags['service'] || '').split(',')
-    const services = (toggle?.tags['services'] || '').split(',')
-    return service.concat(services).includes(serviceName)
-}
+import { ToguruData } from '../models/toguru'
 
 export default (toguruData: ToguruData, service: string): string[] => {
-    const toggles = toguruData.toggles || []
-    const togglesForService = toggles.filter((t) => toggleBelongsToService(t, service))
-    return togglesForService.map((t) => t.id)
+    return toguruData.toggleIdsByService.get(service) || []
 }

--- a/test/mocks/togglestate.fixture.ts
+++ b/test/mocks/togglestate.fixture.ts
@@ -1,6 +1,7 @@
 import { ToguruData } from '../../src/models/toguru'
+import { convertRawToguruDataToToguruData } from '../../src/services/fetchToguruData'
 
-export const toguruData: ToguruData = {
+export const toguruData: ToguruData = convertRawToguruDataToToguruData({
     sequenceNo: 4141,
     toggles: [
         {
@@ -170,4 +171,4 @@ export const toguruData: ToguruData = {
             ],
         },
     ],
-}
+})

--- a/test/services/isToggleEnabled.spec.ts
+++ b/test/services/isToggleEnabled.spec.ts
@@ -29,7 +29,7 @@ const users = {
     attributeUserId123: { attributes: { user: 'user123' } },
 }
 
-const emptyToguruData: ToguruData = { sequenceNo: 0, toggles: [] }
+const emptyToguruData: ToguruData = { sequenceNo: 0, toggles: [], toggleIdsByService: new Map() }
 
 const toggle = (id: string, defaultValue = false) => ({
     id,

--- a/test/services/toggleListForServices.spec.ts
+++ b/test/services/toggleListForServices.spec.ts
@@ -1,16 +1,17 @@
+import { convertRawToguruDataToToguruData } from '../../src/services/fetchToguruData'
 import findToggleListForService from '../../src/services/toggleListForService'
 
 const toggleWithTags = (id: string, tags: Record<string, string>) => {
     return { id, tags: { ...tags }, activations: [] }
 }
-const togglesState = {
+const togglesState = convertRawToguruDataToToguruData({
     sequenceNo: 96,
     toggles: [
         toggleWithTags('toggle-service1-service', { service: 'service1' }),
         toggleWithTags('toggle-service1-services', { services: 'service1,another,anotherone' }),
         toggleWithTags('toggle-no-service1', { services: 'atoggle,another,anotherone' }),
     ],
-}
+})
 
 describe('Find Toggle Names for Service', () => {
     it('works both for both the service and services tag', () => {


### PR DESCRIPTION
While tracing my service I saw that a significant amount of time was spent on `togglesForService`. The reason is that we used to `map` and `filter` over every toggle every time the method was called.
With this PR a lookup table (Map) gets pre-generated when the toggles are fetched and then `togglesForService` only needs to do a cost-effective Map lookup (O(1) vs O(n)). Also we have quite many toggles, so it's a lot of operations to do on every call.